### PR TITLE
Omit undefined value in querystring.stringify

### DIFF
--- a/querystring/index.js
+++ b/querystring/index.js
@@ -5,6 +5,8 @@ function stringify (obj) {
     if (isArray(val)) {
       var l = val.length
       for (var i = 0; i < l; i++) { result += '&' + key + '=' + val[i] }
+    } else if (val === void 0) {
+      result += '&' + key + '='
     } else {
       result += '&' + key + '=' + val
     }

--- a/test/test-querystring.js
+++ b/test/test-querystring.js
@@ -36,6 +36,12 @@ describe('querystring', function () {
     it('should handle empty objects', function () {
       expect(qs.stringify({})).to.eql('')
     })
+    it('should handle undefined object values', function () {
+      expect(qs.stringify({a: undefined, b: 2})).to.eql('?a=&b=2')
+    })
+    it('should handle falsy values except undefined properly', function () {
+      expect(qs.stringify({a: '', c: 32, b: '', d: 4, e: 0, f: false})).to.eql('?a=&c=32&b=&d=4&e=0&f=false')
+    })
     it('should guard against things attached to the prototype', function () {
       var F = function () {}
       F.prototype.a = 'b'


### PR DESCRIPTION
Right now the behavior for `qs.stringify` is as follows

``` js
qs.stringify({
   a: undefined,
   b: 321
}) // Output ?a=undefined&b=321
```

If we `JSON.stringify` the same string `a` will be omitted. Moreover, `{a: undefined}` will be parsed as `a="undefined"` which is not the correct answer. I hope my PR gets accepted. It's going to help me in my hacktoberfest journey too :+1: 
